### PR TITLE
JANITORIAL: Get rid of file suffixes in the code

### DIFF
--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -4172,7 +4172,7 @@ void BotCheckEvents(bot_state_t *bs, entityState_t *state) {
 			// check out the sound
 			trap_GetConfigstring(CS_SOUNDS + state->eventParm, buf, sizeof(buf));
 			// if falling into a death pit
-			if (!strcmp(buf, "*falling1.wav")) {
+			if (!strcmp(buf, "*falling1")) {
 				// if the bot has a personal teleporter
 				if (bs->inventory[INVENTORY_TELEPORTER] > 0) {
 					// use the holdable item


### PR DESCRIPTION
We support different file types for images, models and sounds - there should be any extension included in the code.

Most of the functions in quake3 are removing the extension anyway and try to loop over all supported file types by attaching the extension from a list of supported file types. There might be locations where this is missing. This PR should ensure, that we can use any of the supported file types no matter which extension was given for images and sounds (and also models)