### PR TITLE
ALL: remove file extensions to support more than tga

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -2242,7 +2242,7 @@ static void CG_DrawDisconnect( void ) {
 
 	y = 480 - 48;
 
-	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader("gfx/2d/net.tga" ) );
+	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader("gfx/2d/net" ) );
 }
 
 

--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -123,15 +123,15 @@ void CG_LoadingClient( int clientNum ) {
 			skin = DEFAULT_SKIN;
 		}
 
-		Com_sprintf( iconName, MAX_QPATH, "models/wop_players/%s/icon_%s.tga", model, skin );
-		
+		Com_sprintf( iconName, MAX_QPATH, "models/wop_players/%s/icon_%s", model, skin );
+
 		loadingPlayerIcons[loadingPlayerIconCount] = trap_R_RegisterShaderNoMip( iconName );
 		if ( !loadingPlayerIcons[loadingPlayerIconCount] ) {
-			Com_sprintf( iconName, MAX_QPATH, "models/wop_players/characters/%s/icon_%s.tga", model, skin );
+			Com_sprintf( iconName, MAX_QPATH, "models/wop_players/characters/%s/icon_%s", model, skin );
 			loadingPlayerIcons[loadingPlayerIconCount] = trap_R_RegisterShaderNoMip( iconName );
 		}
 		if ( !loadingPlayerIcons[loadingPlayerIconCount] ) {
-			Com_sprintf( iconName, MAX_QPATH, "models/wop_players/%s/icon_%s.tga", DEFAULT_MODEL, DEFAULT_SKIN );
+			Com_sprintf( iconName, MAX_QPATH, "models/wop_players/%s/icon_%s", DEFAULT_MODEL, DEFAULT_SKIN );
 			loadingPlayerIcons[loadingPlayerIconCount] = trap_R_RegisterShaderNoMip( iconName );
 		}
 		if ( loadingPlayerIcons[loadingPlayerIconCount] ) {
@@ -186,29 +186,29 @@ void CG_DrawInformation( void ) {
 
 	switch ( cgs.gametype ) {
 		case GT_BALLOON:
-			info = "menu/help/loadinghelp_bb.tga";
+			info = "menu/help/loadinghelp_bb";
 			break;
 		case GT_CTF:
-			info = "menu/help/loadinghelp_ctl.tga";
+			info = "menu/help/loadinghelp_ctl";
 			break;
 		case GT_FFA:
-			info = "menu/help/loadinghelp_ffa.tga";
+			info = "menu/help/loadinghelp_ffa";
 			break;
 		case GT_LPS:
-			info = "menu/help/loadinghelp_lps.tga";
+			info = "menu/help/loadinghelp_lps";
 			break;
 		case GT_SPRAYFFA:
-			info = "menu/help/loadinghelp_syc.tga";
+			info = "menu/help/loadinghelp_syc";
 			break;
 		case GT_SPRAY:
-			info = "menu/help/loadinghelp_teamsyc.tga";
+			info = "menu/help/loadinghelp_teamsyc";
 			break;
 		case GT_TEAM:
-			info = "menu/help/loadinghelp_teamffa.tga";
+			info = "menu/help/loadinghelp_teamffa";
 			break;
 
 		default:
-			info = "menu/help/loadinghelp_ffa.tga";
+			info = "menu/help/loadinghelp_ffa";
 			break;
 	}
 

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -958,27 +958,27 @@ static void CG_RegisterGraphics( void ) {
 	}
 
 	for ( i = 0; i <= 4; i++ ) {
-		cgs.media.botSkillShaders[i] = trap_R_RegisterShader( va( "menu/art/skill%i.tga", ( i + 1 ) ) );
+		cgs.media.botSkillShaders[i] = trap_R_RegisterShader( va( "menu/art/skill%i", ( i + 1 ) ) );
 	}
 
 	cgs.media.BloodScreenShader		= trap_R_RegisterShaderNoMip( "blood_screen" );
 	cgs.media.BerserkerScreenShader	= trap_R_RegisterShaderNoMip( "berserker_screen" );
 	cgs.media.WetScreenShader		= trap_R_RegisterShaderNoMip( "wet_screen" );
 
-	cgs.media.deferShader = trap_R_RegisterShaderNoMip( "gfx/2d/defer.tga" );
+	cgs.media.deferShader = trap_R_RegisterShaderNoMip( "gfx/2d/defer" );
 
-	cgs.media.scoreboardBG			= trap_R_RegisterShaderNoMip( "scoreboard/bg.tga");
-	cgs.media.scoreboardName			= trap_R_RegisterShaderNoMip( "scoreboard/name.tga" );
-	cgs.media.scoreboardPing			= trap_R_RegisterShaderNoMip( "scoreboard/ping.tga" );
-	cgs.media.scoreboardScore		= trap_R_RegisterShaderNoMip( "scoreboard/score.tga" );
-	cgs.media.scoreboardTime			= trap_R_RegisterShaderNoMip( "scoreboard/time.tga" );
-	cgs.media.voiceIcon				= trap_R_RegisterShaderNoMip( "hud/voiceIcon.tga" );
+	cgs.media.scoreboardBG			= trap_R_RegisterShaderNoMip( "scoreboard/bg");
+	cgs.media.scoreboardName			= trap_R_RegisterShaderNoMip( "scoreboard/name" );
+	cgs.media.scoreboardPing			= trap_R_RegisterShaderNoMip( "scoreboard/ping" );
+	cgs.media.scoreboardScore		= trap_R_RegisterShaderNoMip( "scoreboard/score" );
+	cgs.media.scoreboardTime			= trap_R_RegisterShaderNoMip( "scoreboard/time" );
+	cgs.media.voiceIcon				= trap_R_RegisterShaderNoMip( "hud/voiceIcon" );
 
 	cgs.media.healthstationIcon = trap_R_RegisterShaderNoMip( "icons/healthstation" );
 
 	if ( cgs.gametype == GT_LPS || cg_buildScript.integer ) {
-		cgs.media.scoreboardlivesleft		= trap_R_RegisterShaderNoMip( "scoreboard/livesleft.tga" );
-		cgs.media.scoreboardscore_lives	= trap_R_RegisterShaderNoMip( "scoreboard/score_lives.tga" );
+		cgs.media.scoreboardlivesleft		= trap_R_RegisterShaderNoMip( "scoreboard/livesleft" );
+		cgs.media.scoreboardscore_lives	= trap_R_RegisterShaderNoMip( "scoreboard/score_lives" );
 
 		cgs.media.lpsIcon		= trap_R_RegisterShaderNoMip( "icons/LPSwallhackicon");
 		cgs.media.lpsIconLead	= trap_R_RegisterShaderNoMip( "icons/LPSwallhackleadicon" );
@@ -1021,66 +1021,66 @@ static void CG_RegisterGraphics( void ) {
 
 	CG_ChangeLoadingProgress( 0.6f );
 
-	cgs.media.hud_bl[1]	= trap_R_RegisterShaderNoMip( "hud/bl_red.tga" );
-	cgs.media.hud_bc[1]	= trap_R_RegisterShaderNoMip( "hud/bc_red.tga" );
-		
-	cgs.media.hud_bl[2]	= trap_R_RegisterShaderNoMip( "hud/bl_blue.tga" );
-	cgs.media.hud_bc[2]	= trap_R_RegisterShaderNoMip( "hud/bc_blue.tga" );
+	cgs.media.hud_bl[1]	= trap_R_RegisterShaderNoMip( "hud/bl_red" );
+	cgs.media.hud_bc[1]	= trap_R_RegisterShaderNoMip( "hud/bc_red" );
+
+	cgs.media.hud_bl[2]	= trap_R_RegisterShaderNoMip( "hud/bl_blue" );
+	cgs.media.hud_bc[2]	= trap_R_RegisterShaderNoMip( "hud/bc_blue" );
 
 	if ( ( cgs.gametype == GT_SPRAY || cgs.gametype == GT_SPRAYFFA ) || cg_buildScript.integer ) {
-		cgs.media.hud_br[0]	= trap_R_RegisterShaderNoMip( "hud/br.tga" );
-		cgs.media.hud_br[1]	= trap_R_RegisterShaderNoMip( "hud/br_red.tga" );
-		cgs.media.hud_br[2]	= trap_R_RegisterShaderNoMip( "hud/br_blue.tga" );
-		cgs.media.hud_br[3]	= trap_R_RegisterShaderNoMip( "hud/br_green.tga" );
-		cgs.media.hud_br[4]	= trap_R_RegisterShaderNoMip( "hud/br_chrome.tga" );
-		cgs.media.hud_br[5]	= trap_R_RegisterShaderNoMip( "hud/br_whitemetal.tga" );
-		cgs.media.hud_br[6]	= trap_R_RegisterShaderNoMip( "hud/br_rust.tga" );
-		cgs.media.hud_br[7]	= trap_R_RegisterShaderNoMip( "hud/br_flower.tga" );
-		cgs.media.hud_br[8]	= trap_R_RegisterShaderNoMip( "hud/br_wood.tga" );
-		cgs.media.hud_br[9]	= trap_R_RegisterShaderNoMip( "hud/br_airforce.tga" );
+		cgs.media.hud_br[0]	= trap_R_RegisterShaderNoMip( "hud/br" );
+		cgs.media.hud_br[1]	= trap_R_RegisterShaderNoMip( "hud/br_red" );
+		cgs.media.hud_br[2]	= trap_R_RegisterShaderNoMip( "hud/br_blue" );
+		cgs.media.hud_br[3]	= trap_R_RegisterShaderNoMip( "hud/br_green" );
+		cgs.media.hud_br[4]	= trap_R_RegisterShaderNoMip( "hud/br_chrome" );
+		cgs.media.hud_br[5]	= trap_R_RegisterShaderNoMip( "hud/br_whitemetal" );
+		cgs.media.hud_br[6]	= trap_R_RegisterShaderNoMip( "hud/br_rust" );
+		cgs.media.hud_br[7]	= trap_R_RegisterShaderNoMip( "hud/br_flower" );
+		cgs.media.hud_br[8]	= trap_R_RegisterShaderNoMip( "hud/br_wood" );
+		cgs.media.hud_br[9]	= trap_R_RegisterShaderNoMip( "hud/br_airforce" );
 
 		cgs.media.sprayroomIcon = trap_R_RegisterShaderNoMip( "icons/sprayroom" );
 	}
 
 	if ( cgs.gametype < GT_TEAM || cg_buildScript.integer ) {
-		cgs.media.hud_bl[0]	= trap_R_RegisterShaderNoMip( "hud/bl.tga" );
-		cgs.media.hud_bc[0]	= trap_R_RegisterShaderNoMip( "hud/bc.tga" );
+		cgs.media.hud_bl[0]	= trap_R_RegisterShaderNoMip( "hud/bl" );
+		cgs.media.hud_bc[0]	= trap_R_RegisterShaderNoMip( "hud/bc" );
 
-		cgs.media.hud_bl[3]	= trap_R_RegisterShaderNoMip( "hud/bl_green.tga" );
-		cgs.media.hud_bc[3]	= trap_R_RegisterShaderNoMip( "hud/bc_green.tga" );
-		
-		cgs.media.hud_bl[4]	= trap_R_RegisterShaderNoMip( "hud/bl_chrome.tga" );
-		cgs.media.hud_bc[4]	= trap_R_RegisterShaderNoMip( "hud/bc_chrome.tga" );
-		
-		cgs.media.hud_bl[5]	= trap_R_RegisterShaderNoMip( "hud/bl_whitemetal.tga" );
-		cgs.media.hud_bc[5]	= trap_R_RegisterShaderNoMip( "hud/bc_whitemetal.tga" );
-		
-		cgs.media.hud_bl[6]	= trap_R_RegisterShaderNoMip( "hud/bl_rust.tga" );
-		cgs.media.hud_bc[6]	= trap_R_RegisterShaderNoMip( "hud/bc_rust.tga" );
-		
-		cgs.media.hud_bl[7]	= trap_R_RegisterShaderNoMip( "hud/bl_flower.tga" );
-		cgs.media.hud_bc[7]	= trap_R_RegisterShaderNoMip( "hud/bc_flower.tga" );
-		
-		cgs.media.hud_bl[8]	= trap_R_RegisterShaderNoMip( "hud/bl_wood.tga" );
-		cgs.media.hud_bc[8]	= trap_R_RegisterShaderNoMip( "hud/bc_wood.tga" );
-		
-		cgs.media.hud_bl[9]	= trap_R_RegisterShaderNoMip( "hud/bl_airforce.tga" );
-		cgs.media.hud_bc[9]	= trap_R_RegisterShaderNoMip( "hud/bc_airforce.tga" );
+		cgs.media.hud_bl[3]	= trap_R_RegisterShaderNoMip( "hud/bl_green" );
+		cgs.media.hud_bc[3]	= trap_R_RegisterShaderNoMip( "hud/bc_green" );
+
+		cgs.media.hud_bl[4]	= trap_R_RegisterShaderNoMip( "hud/bl_chrome" );
+		cgs.media.hud_bc[4]	= trap_R_RegisterShaderNoMip( "hud/bc_chrome" );
+
+		cgs.media.hud_bl[5]	= trap_R_RegisterShaderNoMip( "hud/bl_whitemetal" );
+		cgs.media.hud_bc[5]	= trap_R_RegisterShaderNoMip( "hud/bc_whitemetal" );
+
+		cgs.media.hud_bl[6]	= trap_R_RegisterShaderNoMip( "hud/bl_rust" );
+		cgs.media.hud_bc[6]	= trap_R_RegisterShaderNoMip( "hud/bc_rust" );
+
+		cgs.media.hud_bl[7]	= trap_R_RegisterShaderNoMip( "hud/bl_flower" );
+		cgs.media.hud_bc[7]	= trap_R_RegisterShaderNoMip( "hud/bc_flower" );
+
+		cgs.media.hud_bl[8]	= trap_R_RegisterShaderNoMip( "hud/bl_wood" );
+		cgs.media.hud_bc[8]	= trap_R_RegisterShaderNoMip( "hud/bc_wood" );
+
+		cgs.media.hud_bl[9]	= trap_R_RegisterShaderNoMip( "hud/bl_airforce" );
+		cgs.media.hud_bc[9]	= trap_R_RegisterShaderNoMip( "hud/bc_airforce" );
 	}
 	else {
 		cgs.media.friendShader	= trap_R_RegisterShader( "sprites/foe" );
 
 		if ( cgs.gametype == GT_BALLOON || cg_buildScript.integer ) {
-			cgs.media.hud_bk_balloon_red	= trap_R_RegisterShaderNoMip( "hud/bk_balloon_red.tga" );
-			cgs.media.hud_bk_balloon_blue	= trap_R_RegisterShaderNoMip( "hud/bk_balloon_blue.tga" );
-			cgs.media.hud_balloon		= trap_R_RegisterShaderNoMip( "hud/balloonicon.tga" );
-			cgs.media.hud_balloon_bar	= trap_R_RegisterShaderNoMip( "hud/balloonbar.tga" );
+			cgs.media.hud_bk_balloon_red	= trap_R_RegisterShaderNoMip( "hud/bk_balloon_red" );
+			cgs.media.hud_bk_balloon_blue	= trap_R_RegisterShaderNoMip( "hud/bk_balloon_blue" );
+			cgs.media.hud_balloon		= trap_R_RegisterShaderNoMip( "hud/balloonicon" );
+			cgs.media.hud_balloon_bar	= trap_R_RegisterShaderNoMip( "hud/balloonbar" );
 			cgs.media.boomiesSphereModel = trap_R_RegisterModel( "models/weaponsfx/boomiessphere.md3" );
 			cgs.media.boomiesCoreShader  = trap_R_RegisterShader( "boomiesCore" );
 		}
 		else if ( cgs.gametype == GT_CTF || cg_buildScript.integer ) {
-			cgs.media.hud_CTL_bg_red		= trap_R_RegisterShaderNoMip( "hud/CTL_red.tga" );
-			cgs.media.hud_CTL_bg_blue	= trap_R_RegisterShaderNoMip( "hud/CTL_blue.tga" );
+			cgs.media.hud_CTL_bg_red		= trap_R_RegisterShaderNoMip( "hud/CTL_red" );
+			cgs.media.hud_CTL_bg_blue	= trap_R_RegisterShaderNoMip( "hud/CTL_blue" );
 
 			cgs.media.redFlagModel	= trap_R_RegisterModel( "models/ctl/lollipop_red.md3" );
 			cgs.media.blueFlagModel	= trap_R_RegisterModel( "models/ctl/lollipop_blue.md3" );
@@ -1103,8 +1103,8 @@ static void CG_RegisterGraphics( void ) {
 			cgs.media.bambamImpactDropsRedShader	= trap_R_RegisterShader("models/weaponsfx/bambamdrop_red");
 			cgs.media.bambamImpactDropsBlueShader	= trap_R_RegisterShader("models/weaponsfx/bambamdrop_blue");
 
-			cgs.media.bambamHealthIconBG	= trap_R_RegisterShaderNoMip( "models/weapons2/bambam/bamhealth01.tga" );
-			cgs.media.bambamHealthIcon		= trap_R_RegisterShaderNoMip( "models/weapons2/bambam/bamhealth02.tga" );
+			cgs.media.bambamHealthIconBG	= trap_R_RegisterShaderNoMip( "models/weapons2/bambam/bamhealth01" );
+			cgs.media.bambamHealthIcon		= trap_R_RegisterShaderNoMip( "models/weapons2/bambam/bamhealth02" );
 		}
 
 		if ( ( cgs.gametype == GT_CTF ) || ( cgs.gametype == GT_BALLOON ) || cg_buildScript.integer ) {
@@ -1115,15 +1115,15 @@ static void CG_RegisterGraphics( void ) {
 
 	CG_ChangeLoadingProgress( 0.7f );
 
-	cgs.media.hud_teammarker		= trap_R_RegisterShaderNoMip( "hud/teammarker.tga" );
-	cgs.media.hud_shieldbar		= trap_R_RegisterShaderNoMip( "hud/shieldbar.tga" );
-	cgs.media.hud_energybar		= trap_R_RegisterShaderNoMip( "hud/energybar.tga" );
-	cgs.media.hud_shieldbar2		= trap_R_RegisterShaderNoMip( "hud/shieldbar2.tga" );
-	cgs.media.hud_energybar2		= trap_R_RegisterShaderNoMip( "hud/energybar2.tga" );
-	cgs.media.hud_shieldglass	= trap_R_RegisterShaderNoMip( "hud/shield_glass.tga" );
-	cgs.media.hud_energyglass	= trap_R_RegisterShaderNoMip( "hud/energy_glass.tga" );
-	cgs.media.hud_dotfull		= trap_R_RegisterShaderNoMip( "hud/dotfull.tga" );
-	cgs.media.hud_dotempty		= trap_R_RegisterShaderNoMip( "hud/dotempty.tga" );
+	cgs.media.hud_teammarker		= trap_R_RegisterShaderNoMip( "hud/teammarker" );
+	cgs.media.hud_shieldbar		= trap_R_RegisterShaderNoMip( "hud/shieldbar" );
+	cgs.media.hud_energybar		= trap_R_RegisterShaderNoMip( "hud/energybar" );
+	cgs.media.hud_shieldbar2		= trap_R_RegisterShaderNoMip( "hud/shieldbar2" );
+	cgs.media.hud_energybar2		= trap_R_RegisterShaderNoMip( "hud/energybar2" );
+	cgs.media.hud_shieldglass	= trap_R_RegisterShaderNoMip( "hud/shield_glass" );
+	cgs.media.hud_energyglass	= trap_R_RegisterShaderNoMip( "hud/energy_glass" );
+	cgs.media.hud_dotfull		= trap_R_RegisterShaderNoMip( "hud/dotfull" );
+	cgs.media.hud_dotempty		= trap_R_RegisterShaderNoMip( "hud/dotempty" );
 
 
 	cgs.media.star = trap_R_RegisterModel( "models/weaponsfx/star.md3" );
@@ -2008,9 +2008,9 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	}
 
 	cgs.media.whiteShader		= trap_R_RegisterShader( "white" );
-	cgs.media.charsetProp		= trap_R_RegisterShaderNoMip( "menu/art/font1_prop.tga" );
-	cgs.media.charsetPropGlow	= trap_R_RegisterShaderNoMip( "menu/art/font1_prop_glo.tga" );
-	cgs.media.charsetPropB		= trap_R_RegisterShaderNoMip( "menu/art/font2_prop.tga" );
+	cgs.media.charsetProp		= trap_R_RegisterShaderNoMip( "menu/art/font1_prop" );
+	cgs.media.charsetPropGlow	= trap_R_RegisterShaderNoMip( "menu/art/font1_prop_glo" );
+	cgs.media.charsetPropB		= trap_R_RegisterShaderNoMip( "menu/art/font2_prop" );
 
 	CG_RegisterCvars();
 

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -580,7 +580,9 @@ static qboolean CG_RegisterClientModelname( clientInfo_t *ci, const char *modelN
 	}
 
 
-	if ( CG_FindClientHeadFile( filename, sizeof( filename ), ci, NULL, headModelName, headSkinName, "icon", "tga" ) ) {
+	if ( CG_FindClientHeadFile( filename, sizeof( filename ), ci, NULL, headModelName, headSkinName, "icon", "png" ) ) {
+		ci->modelIcon = trap_R_RegisterShaderNoMip( filename );
+	} else if ( CG_FindClientHeadFile( filename, sizeof( filename ), ci, NULL, headModelName, headSkinName, "icon", "tga" ) ) {
 		ci->modelIcon = trap_R_RegisterShaderNoMip( filename );
 	}
 	else if ( CG_FindClientHeadFile( filename, sizeof( filename ), ci, NULL, headModelName, headSkinName, "icon", "skin" ) ) {

--- a/code/cgame/cg_spraylogo.c
+++ b/code/cgame/cg_spraylogo.c
@@ -229,10 +229,10 @@ void Init_SprayLogoSys(void)
 {
 	cgs.media.spraypuff			= trap_R_RegisterShader("weaponeffect/spraypuff");
 	cgs.media.spraymark			= trap_R_RegisterShader("weaponeffect/spraymark");
-	cgs.media.slmenu_arrowr		= trap_R_RegisterShaderNoMip("menu/spraylogo/slmenu_arrowr.tga");
-	cgs.media.slmenu_arrowl		= trap_R_RegisterShaderNoMip("menu/spraylogo/slmenu_arrowl.tga");
+	cgs.media.slmenu_arrowr		= trap_R_RegisterShaderNoMip("menu/spraylogo/slmenu_arrowr");
+	cgs.media.slmenu_arrowl		= trap_R_RegisterShaderNoMip("menu/spraylogo/slmenu_arrowl");
 	cgs.media.cgwopmenu_cursor	= trap_R_RegisterShaderNoMip( "menu/art/3_cursor2" );
-	cgs.media.chooselogo_bg		= trap_R_RegisterShaderNoMip("menu/spraylogo/bg.tga");
+	cgs.media.chooselogo_bg		= trap_R_RegisterShaderNoMip("menu/spraylogo/bg");
 	Load_Logos();
 	Init_LogoPolyList();
 

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -617,9 +617,9 @@ NOADDITIONALMODELS:
 		for ( i = 0; i <= 8; i++ ) {
 			cgs.media.zoomsound[i] = trap_S_RegisterSound( va( "sounds/weapons/splasher/zoom0%i", i ), qtrue );
 		}
-		cgs.media.zoomhud			= trap_R_RegisterShaderNoMip( "zoomhud.tga" );
-		cgs.media.zoomruler			= trap_R_RegisterShaderNoMip( "zoomruler.tga" );
-		cgs.media.zoomcompass		= trap_R_RegisterShaderNoMip( "zoomcompass.tga" );
+		cgs.media.zoomhud			= trap_R_RegisterShaderNoMip( "zoomhud" );
+		cgs.media.zoomruler			= trap_R_RegisterShaderNoMip( "zoomruler" );
+		cgs.media.zoomcompass		= trap_R_RegisterShaderNoMip( "zoomcompass" );
 		break;
 
 	case WP_KMA97:
@@ -633,7 +633,7 @@ NOADDITIONALMODELS:
 		cgs.media.kmaTrailShader	= trap_R_RegisterShader( "kmaTrail" );
 		cgs.media.kmaBallShader		= trap_R_RegisterShader( "kmaBall" );
 		cgs.media.smallKmaDropModel	= trap_R_RegisterModel( "models/weaponsfx/smallkmadrop.md3" );
-		cgs.media.zoomhud_kma		= trap_R_RegisterShaderNoMip( "zoomhud_kma.tga" );
+		cgs.media.zoomhud_kma		= trap_R_RegisterShaderNoMip( "zoomhud_kma" );
 		cgs.media.zoomKMAaura		= trap_R_RegisterShader( "gfx/kmazoomAura" );
 		cgs.media.zoomKMAbluescreen	= trap_R_RegisterShader( "gfx/kmaBlueScreen" );
 		break;

--- a/code/q3_ui/ui_addbots.c
+++ b/code/q3_ui/ui_addbots.c
@@ -32,10 +32,10 @@ ADD BOTS MENU
 #include "ui_local.h"
 
 
-#define ART_ARROWUP0		"menu/mods/arrowup0.tga"
-#define ART_ARROWUP1		"menu/mods/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/mods/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/mods/arrowdown1.tga"
+#define ART_ARROWUP0		"menu/mods/arrowup0"
+#define ART_ARROWUP1		"menu/mods/arrowup1"
+#define ART_ARROWDOWN0		"menu/mods/arrowdown0"
+#define ART_ARROWDOWN1		"menu/mods/arrowdown1"
 
 #define NUM_BOTS			6
 

--- a/code/q3_ui/ui_atoms.c
+++ b/code/q3_ui/ui_atoms.c
@@ -1739,10 +1739,10 @@ void UI_ModelIcon(const char *modelAndSkin, char *iconName, int SizeOfIconName)
 		skin = "default";
 	}
 
-	Com_sprintf(iconName, SizeOfIconName, "models/wop_players/%s/icon_%s.tga", model, skin );
+	Com_sprintf(iconName, SizeOfIconName, "models/wop_players/%s/icon_%s", model, skin );
 
 	if( !trap_R_RegisterShaderNoMip( iconName ) && Q_stricmp( skin, "default" ) != 0 ) {
-		Com_sprintf(iconName, SizeOfIconName, "models/wop_players/%s/icon_default.tga", model );
+		Com_sprintf(iconName, SizeOfIconName, "models/wop_players/%s/icon_default", model );
 	}
 }
 

--- a/code/q3_ui/ui_callvote.c
+++ b/code/q3_ui/ui_callvote.c
@@ -12,10 +12,10 @@ CALL VOTE MENU
 #include "ui_local.h"
 
 
-#define ART_ARROWUP0		"menu/mods/arrowup0.tga"
-#define ART_ARROWUP1		"menu/mods/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/mods/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/mods/arrowdown1.tga"
+#define ART_ARROWUP0		"menu/mods/arrowup0"
+#define ART_ARROWUP1		"menu/mods/arrowup1"
+#define ART_ARROWDOWN0		"menu/mods/arrowdown0"
+#define ART_ARROWDOWN1		"menu/mods/arrowdown1"
 
 #define ID_BACK				10
 #define ID_GO				11

--- a/code/q3_ui/ui_cdkey.c
+++ b/code/q3_ui/ui_cdkey.c
@@ -32,9 +32,9 @@ CD KEY MENU
 #include "ui_local.h"
 
 
-#define ART_FRAME		"cdkey.tga"
+#define ART_FRAME		"cdkey"
 #define ART_ACCEPT0		"menu/system/accept"
-#define ART_ACCEPT1		"menu/system/accept"	
+#define ART_ACCEPT1		"menu/system/accept"
 #define ART_BACK0		"menu/BtnBack0"
 #define ART_BACK1		"menu/BtnBack1"
 

--- a/code/q3_ui/ui_demo2.c
+++ b/code/q3_ui/ui_demo2.c
@@ -33,13 +33,13 @@ DEMOS MENU
 
 
 #define ART_BACK0			"menu/BtnBack0"
-#define ART_BACK1			"menu/BtnBack1"	
+#define ART_BACK1			"menu/BtnBack1"
 #define ART_GO0				"menu/demo/play0"
 #define ART_GO1				"menu/demo/play1"
-#define ART_ARROWUP0		"menu/demo/arrowup0.tga"
-#define ART_ARROWUP1		"menu/demo/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/demo/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/demo/arrowdown1.tga"
+#define ART_ARROWUP0		"menu/demo/arrowup0"
+#define ART_ARROWUP1		"menu/demo/arrowup1"
+#define ART_ARROWDOWN0		"menu/demo/arrowdown0"
+#define ART_ARROWDOWN1		"menu/demo/arrowdown1"
 
 #define MAX_DEMOS			1024
 #define NAMEBUFSIZE			( MAX_DEMOS * 32 )

--- a/code/q3_ui/ui_gameinfo.c
+++ b/code/q3_ui/ui_gameinfo.c
@@ -838,10 +838,10 @@ void UI_SearchSpraylogos( void ) {
 	
 		nameLen = strlen( namePtr );
 		
-		// ignore anything but jpg and tga
-		if( !nameLen 
-			|| !ext 
-			|| ( Q_stricmp(".jpg", Q_strlwr(ext)) != 0 && Q_stricmp(".tga", Q_strlwr(ext)) != 0 )
+		// ignore anything but jpg, png and tga
+		if( !nameLen
+			|| !ext
+			|| ( Q_stricmp(".jpg", Q_strlwr(ext)) != 0 && Q_stricmp(".tga", Q_strlwr(ext)) != 0 && Q_stricmp(".png", Q_strlwr(ext)) != 0 )
 			)
 			continue;
 

--- a/code/q3_ui/ui_mods.c
+++ b/code/q3_ui/ui_mods.c
@@ -24,12 +24,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define ART_BACK0			"menu/BtnBack0"
 #define ART_BACK1			"menu/BtnBack1"	
-#define ART_FIGHT0			"menu/mods/load0.tga"
-#define ART_FIGHT1			"menu/mods/load1.tga"
-#define ART_ARROWUP0		"menu/mods/arrowup0.tga"
-#define ART_ARROWUP1		"menu/mods/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/mods/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/mods/arrowdown1.tga"
+#define ART_FIGHT0			"menu/mods/load0"
+#define ART_FIGHT1			"menu/mods/load1"
+#define ART_ARROWUP0		"menu/mods/arrowup0"
+#define ART_ARROWUP1		"menu/mods/arrowup1"
+#define ART_ARROWDOWN0		"menu/mods/arrowdown0"
+#define ART_ARROWDOWN1		"menu/mods/arrowdown1"
 
 #define MAX_MODS			64
 #define NAMEBUFSIZE			( MAX_MODS * 48 )

--- a/code/q3_ui/ui_music.c
+++ b/code/q3_ui/ui_music.c
@@ -29,7 +29,7 @@
 
 #include "ui_local.h"
 
-#define MUSIC_BG_ARM "wopmusic/bg_arm.tga"
+#define MUSIC_BG_ARM "wopmusic/bg_arm"
 
 #define MAX_TRACKS			15
 #define MAX_ALBUMS			10

--- a/code/q3_ui/ui_playermodel.c
+++ b/code/q3_ui/ui_playermodel.c
@@ -412,14 +412,14 @@ static void PlayerModel_BuildList( void )
 	for (i=0; i<numdirs && s_playermodel.nummodels < MAX_PLAYERMODELS; i++,dirptr+=dirlen+1)
 	{
 		dirlen = strlen(dirptr);
-		
+
 		if (dirlen && dirptr[dirlen-1]=='/') dirptr[dirlen-1]='\0';
 
 		if (!strcmp(dirptr,".") || !strcmp(dirptr,".."))
 			continue;
-			
+
 		// iterate all skin files in directory
-		numfiles = trap_FS_GetFileList( va("models/wop_players/%s",dirptr), "tga", filelist, 2048 );
+		numfiles = trap_FS_GetFileList( va("models/wop_players/%s",dirptr), "tga;png", filelist, 2048 );
 		fileptr  = filelist;
 		for (j=0; j<numfiles && s_playermodel.nummodels < MAX_PLAYERMODELS;j++,fileptr+=filelen+1)
 		{

--- a/code/q3_ui/ui_playersettings.c
+++ b/code/q3_ui/ui_playersettings.c
@@ -565,9 +565,9 @@ static void PlayerSettings_BuildList( void )
 		if (!( ps_playericons.modelicons[ps_playericons.nummodel]=trap_R_RegisterShaderNoMip(va("models/wop_players/%s/wop_menu",dirptr)) ))
 			continue;
 		ps_playericons.modeliconsB[ps_playericons.nummodel]=trap_R_RegisterShaderNoMip(va("models/wop_players/%s/wop_menuB",dirptr));
-		
+
 		// iterate all skin files in directory
-		numfiles = trap_FS_GetFileList( va("models/wop_players/%s",dirptr), "tga", filelist, MAX_MODELFOLDER_FILELIST );
+		numfiles = trap_FS_GetFileList( va("models/wop_players/%s",dirptr), "tga;png", filelist, MAX_MODELFOLDER_FILELIST );
 		fileptr  = filelist;
 		for (j=0; j<numfiles && ps_playericons.lastskinicon[ps_playericons.nummodel] < MAX_SKINS;j++,fileptr+=filelen+1)
 		{
@@ -821,8 +821,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.modelsleft.sy				= 38;
 	s_playersettings.modelsleft.sw				= 56;
 	s_playersettings.modelsleft.sh				= 117;
-	s_playersettings.modelsleft.shader			= trap_R_RegisterShaderNoMip("menu/player/left.tga");
-	s_playersettings.modelsleft.mouseovershader	= trap_R_RegisterShaderNoMip("menu/player/left_mOver.tga");
+	s_playersettings.modelsleft.shader			= trap_R_RegisterShaderNoMip("menu/player/left");
+	s_playersettings.modelsleft.mouseovershader	= trap_R_RegisterShaderNoMip("menu/player/left_mOver");
 	s_playersettings.modelsleft.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.modelsleft.generic.id		= ID_MODELSLEFT;
 
@@ -837,8 +837,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.modelsright.sy				= 35;
 	s_playersettings.modelsright.sw				= 58;
 	s_playersettings.modelsright.sh				= 120;
-	s_playersettings.modelsright.shader			= trap_R_RegisterShaderNoMip("menu/player/right.tga");
-	s_playersettings.modelsright.mouseovershader= trap_R_RegisterShaderNoMip("menu/player/right_mOver.tga");
+	s_playersettings.modelsright.shader			= trap_R_RegisterShaderNoMip("menu/player/right");
+	s_playersettings.modelsright.mouseovershader= trap_R_RegisterShaderNoMip("menu/player/right_mOver");
 	s_playersettings.modelsright.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.modelsright.generic.id		= ID_MODELSRIGHT;
 
@@ -853,8 +853,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.skinup.sy				= 199;
 	s_playersettings.skinup.sw				= 119;
 	s_playersettings.skinup.sh				= 39;
-	s_playersettings.skinup.shader			= trap_R_RegisterShaderNoMip("menu/player/up.tga");
-	s_playersettings.skinup.mouseovershader	= trap_R_RegisterShaderNoMip("menu/player/up_mOver.tga");
+	s_playersettings.skinup.shader			= trap_R_RegisterShaderNoMip("menu/player/up");
+	s_playersettings.skinup.mouseovershader	= trap_R_RegisterShaderNoMip("menu/player/up_mOver");
 	s_playersettings.skinup.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.skinup.generic.id		= ID_SKINSUP;
 
@@ -869,8 +869,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.skindown.sy			= 692;
 	s_playersettings.skindown.sw			= 117;
 	s_playersettings.skindown.sh			= 40;
-	s_playersettings.skindown.shader		= trap_R_RegisterShaderNoMip("menu/player/down.tga");
-	s_playersettings.skindown.mouseovershader= trap_R_RegisterShaderNoMip("menu/player/down_mOver.tga");
+	s_playersettings.skindown.shader		= trap_R_RegisterShaderNoMip("menu/player/down");
+	s_playersettings.skindown.mouseovershader= trap_R_RegisterShaderNoMip("menu/player/down_mOver");
 	s_playersettings.skindown.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.skindown.generic.id	= ID_SKINSDOWN;
 
@@ -902,7 +902,7 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.skin_icons[0].sw				= 
 	s_playersettings.skin_icons[0].sh				= 138;
 	s_playersettings.skin_icons[0].shader			= 0;
-	s_playersettings.skin_icons[0].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow.tga");
+	s_playersettings.skin_icons[0].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow");
 	s_playersettings.skin_icons[0].generic.callback	= PlayerSettings_MenuEvent;
 	s_playersettings.skin_icons[0].generic.id		= ID_SICON;
 
@@ -916,7 +916,7 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.skin_icons[1].sw				= 
 	s_playersettings.skin_icons[1].sh				= 138;
 	s_playersettings.skin_icons[1].shader			= 0;
-	s_playersettings.skin_icons[1].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow.tga");
+	s_playersettings.skin_icons[1].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow");
 	s_playersettings.skin_icons[1].generic.callback	= PlayerSettings_MenuEvent;
 	s_playersettings.skin_icons[1].generic.id		= ID_SICON+1;
 
@@ -930,7 +930,7 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.skin_icons[2].sw				= 
 	s_playersettings.skin_icons[2].sh				= 138;
 	s_playersettings.skin_icons[2].shader			= 0;
-	s_playersettings.skin_icons[2].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow.tga");
+	s_playersettings.skin_icons[2].shadowshader		= trap_R_RegisterShaderNoMip("menu/player/sicon_shadow");
 	s_playersettings.skin_icons[2].generic.callback	= PlayerSettings_MenuEvent;
 	s_playersettings.skin_icons[2].generic.id		= ID_SICON+2;
 
@@ -962,8 +962,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.spraylogos_prev.y				= 570;
 	s_playersettings.spraylogos_prev.w				= 40;
 	s_playersettings.spraylogos_prev.h				= 20;
-	s_playersettings.spraylogos_prev.shader			= trap_R_RegisterShaderNoMip("menu/smallarrow_left.tga");
-	s_playersettings.spraylogos_prev.mouseovershader= trap_R_RegisterShaderNoMip("menu/smallarrow_leftdown.tga");
+	s_playersettings.spraylogos_prev.shader			= trap_R_RegisterShaderNoMip("menu/smallarrow_left");
+	s_playersettings.spraylogos_prev.mouseovershader= trap_R_RegisterShaderNoMip("menu/smallarrow_leftdown");
 	s_playersettings.spraylogos_prev.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.spraylogos_prev.generic.id		= ID_SLOGOPREV;
 
@@ -972,8 +972,8 @@ static void PlayerSettings_MenuInit( void ) {
 	s_playersettings.spraylogos_next.y				= 570;
 	s_playersettings.spraylogos_next.w				= 40;
 	s_playersettings.spraylogos_next.h				= 20;
-	s_playersettings.spraylogos_next.shader			= trap_R_RegisterShaderNoMip("menu/smallarrow_right.tga");
-	s_playersettings.spraylogos_next.mouseovershader= trap_R_RegisterShaderNoMip("menu/smallarrow_rightdown.tga");
+	s_playersettings.spraylogos_next.shader			= trap_R_RegisterShaderNoMip("menu/smallarrow_right");
+	s_playersettings.spraylogos_next.mouseovershader= trap_R_RegisterShaderNoMip("menu/smallarrow_rightdown");
 	s_playersettings.spraylogos_next.generic.callback= PlayerSettings_MenuEvent;
 	s_playersettings.spraylogos_next.generic.id		= ID_SLOGONEXT;
 

--- a/code/q3_ui/ui_qmenu.c
+++ b/code/q3_ui/ui_qmenu.c
@@ -2177,9 +2177,9 @@ void Menu_Cache( void )
 	}
 	else
 		uis.charset			= trap_R_RegisterShaderNoMip( "gfx/2d/bigchars" );
-	uis.charsetProp		= trap_R_RegisterShaderNoMip( "menu/art/font1_prop.tga" );
-	uis.charsetPropGlow	= trap_R_RegisterShaderNoMip( "menu/art/font1_prop_glo.tga" );
-	uis.charsetPropB	= trap_R_RegisterShaderNoMip( "menu/art/font2_prop.tga" );
+	uis.charsetProp		= trap_R_RegisterShaderNoMip( "menu/art/font1_prop" );
+	uis.charsetPropGlow	= trap_R_RegisterShaderNoMip( "menu/art/font1_prop_glo" );
+	uis.charsetPropB	= trap_R_RegisterShaderNoMip( "menu/art/font2_prop" );
 	uis.cursor          = trap_R_RegisterShaderNoMip( "menu/art/3_cursor2" );
 	uis.rb_on           = trap_R_RegisterShaderNoMip( "menu/art/switch_on" );
 	uis.rb_off          = trap_R_RegisterShaderNoMip( "menu/art/switch_off" );

--- a/code/q3_ui/ui_removebots.c
+++ b/code/q3_ui/ui_removebots.c
@@ -32,10 +32,10 @@ REMOVE BOTS MENU
 #include "ui_local.h"
 
 
-#define ART_ARROWUP0		"menu/mods/arrowup0.tga"
-#define ART_ARROWUP1		"menu/mods/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/mods/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/mods/arrowdown1.tga"
+#define ART_ARROWUP0		"menu/mods/arrowup0"
+#define ART_ARROWUP1		"menu/mods/arrowup1"
+#define ART_ARROWDOWN0		"menu/mods/arrowdown0"
+#define ART_ARROWDOWN1		"menu/mods/arrowdown1"
 
 #define NUM_BOTS			6
 

--- a/code/q3_ui/ui_splevel.c
+++ b/code/q3_ui/ui_splevel.c
@@ -138,10 +138,10 @@ static void PlayerIcon( const char *modelAndSkin, char *iconName, int iconNameMa
 		skin = "default";
 	}
 
-	Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_%s.tga", model, skin );
+	Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_%s", model, skin );
 
 	if( !trap_R_RegisterShaderNoMip( iconName ) && Q_stricmp( skin, "default" ) != 0 ) {
-		Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_default.tga", model );
+		Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_default", model );
 	}
 }
 
@@ -236,7 +236,7 @@ static void UI_SPLevelMenu_SetMenuArena( int n, int level, const char *arenaInfo
 		levelMenuInfo.levelScores[n] = 8;
 	}
 
-	Com_sprintf( levelMenuInfo.levelPicNames[n], sizeof(levelMenuInfo.levelPicNames[n]), "levelshots/%s.tga", map );
+	Com_sprintf( levelMenuInfo.levelPicNames[n], sizeof(levelMenuInfo.levelPicNames[n]), "levelshots/%s", map );
 	if( !trap_R_RegisterShaderNoMip( levelMenuInfo.levelPicNames[n] ) ) {
 		strcpy( levelMenuInfo.levelPicNames[n], ART_MAP_UNKNOWN );
 	}

--- a/code/q3_ui/ui_spskill.c
+++ b/code/q3_ui/ui_spskill.c
@@ -32,8 +32,8 @@ SINGLE PLAYER SKILL MENU
 
 
 #define ART_FRAME					"menu/art/cut_frame"
-#define ART_BACK					"menu/art/back_0.tga"
-#define ART_BACK_FOCUS				"menu/art/back_1.tga"
+#define ART_BACK					"menu/art/back_0"
+#define ART_BACK_FOCUS				"menu/art/back_1"
 #define ART_FIGHT					"menu/art/fight_0"
 #define ART_FIGHT_FOCUS				"menu/art/fight_1"
 #define ART_MAP_COMPLETE1			"menu/art/level_complete1"

--- a/code/q3_ui/ui_startserver.c
+++ b/code/q3_ui/ui_startserver.c
@@ -952,7 +952,7 @@ void StartServer_Cache( void )
 	trap_R_RegisterShaderNoMip( GAMESERVER_UNKNOWNMAP );
 
 	for(i=0;i<10;i++)
-		s_startserver.mapNumbers[i] = trap_R_RegisterShaderNoMip(va("menu/startserver/%i.tga",i));
+		s_startserver.mapNumbers[i] = trap_R_RegisterShaderNoMip(va("menu/startserver/%i",i));
 
 	s_startserver.nummaps = UI_GetNumArenas();
 
@@ -1097,10 +1097,10 @@ static void ServerPlayerIcon( const char *modelAndSkin, char *iconName, int icon
 		skin = "default";
 	}
 
-	Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_%s.tga", model, skin );
+	Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_%s", model, skin );
 
 	if( !trap_R_RegisterShaderNoMip( iconName ) && Q_stricmp( skin, "default" ) != 0 ) {
-		Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_default.tga", model );
+		Com_sprintf(iconName, iconNameMaxSize, "models/wop_players/%s/icon_default", model );
 	}
 }
 
@@ -1533,7 +1533,7 @@ static void UI_BotSelectMenu_DrawBotIcon(void* self)
 		if (!(Menu_ItemAtCursor( b->generic.parent ) == b))
 		{
 	//		UI_DrawHandlePic( x, y, w, h, b->focusshader );
-			UI_DrawNamedPic(x,y,w+8,h+8,"menu/player/micon_shadow.tga");
+			UI_DrawNamedPic(x,y,w+8,h+8,"menu/player/micon_shadow");
 		}
 
 		UI_DrawHandlePic( x, y, w, h, b->shader );
@@ -1655,8 +1655,8 @@ static void UI_BotSelectMenu_Init(void) {
 	botSelectInfo.arrowup.y					= y;//480-(10*MAX_SELECTLISTBOTS)-20;
 	botSelectInfo.arrowup.w					= 38;
 	botSelectInfo.arrowup.h					= 100;
-	botSelectInfo.arrowup.shader			= trap_R_RegisterShaderNoMip("menu/server/arrowup0.tga");
-	botSelectInfo.arrowup.mouseovershader	= trap_R_RegisterShaderNoMip("menu/server/arrowup1.tga");
+	botSelectInfo.arrowup.shader			= trap_R_RegisterShaderNoMip("menu/server/arrowup0");
+	botSelectInfo.arrowup.mouseovershader	= trap_R_RegisterShaderNoMip("menu/server/arrowup1");
 	botSelectInfo.arrowup.generic.callback	= UI_BotSelectMenu_ListUp;
 
 	botSelectInfo.arrowdown.generic.type	= MTYPE_BITMAP1024S;
@@ -1664,8 +1664,8 @@ static void UI_BotSelectMenu_Init(void) {
 	botSelectInfo.arrowdown.y				= y+(25.6f*MAX_SELECTLISTBOTS)-99;//480+20;
 	botSelectInfo.arrowdown.w				= 38;
 	botSelectInfo.arrowdown.h				= 99;
-	botSelectInfo.arrowdown.shader			= trap_R_RegisterShaderNoMip("menu/server/arrowdown0.tga");
-	botSelectInfo.arrowdown.mouseovershader	= trap_R_RegisterShaderNoMip("menu/server/arrowdown1.tga");
+	botSelectInfo.arrowdown.shader			= trap_R_RegisterShaderNoMip("menu/server/arrowdown0");
+	botSelectInfo.arrowdown.mouseovershader	= trap_R_RegisterShaderNoMip("menu/server/arrowdown1");
 	botSelectInfo.arrowdown.generic.callback= UI_BotSelectMenu_ListDown;
 
 	botSelectInfo.BotSkill.generic.type		= MTYPE_SPINCONTROL;

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -31,7 +31,7 @@ TEAM ORDERS MENU
 
 #include "ui_local.h"
 
-#define ART_FRAME		"menu/ingame/bg.tga"
+#define ART_FRAME		"menu/ingame/bg"
 
 #define ID_LIST_BOTS		10
 #define ID_LIST_CTF_ORDERS	11

--- a/code/q3_ui/ui_voicechat.c
+++ b/code/q3_ui/ui_voicechat.c
@@ -1,10 +1,10 @@
 #include "ui_local.h"
 
 
-#define ART_ARROWUP0		"menu/mods/arrowup0.tga"
-#define ART_ARROWUP1		"menu/mods/arrowup1.tga"
-#define ART_ARROWDOWN0		"menu/mods/arrowdown0.tga"
-#define ART_ARROWDOWN1		"menu/mods/arrowdown1.tga"
+#define ART_ARROWUP0		"menu/mods/arrowup0"
+#define ART_ARROWUP1		"menu/mods/arrowup1"
+#define ART_ARROWDOWN0		"menu/mods/arrowdown0"
+#define ART_ARROWDOWN1		"menu/mods/arrowdown1"
 
 #define NUM_LISTEDCLIENTS	6	// tied to the ID_CLIENTXs
 #define NAME_MAXLENGTH		32

--- a/code/q3_ui/ui_wopsp.c
+++ b/code/q3_ui/ui_wopsp.c
@@ -4,14 +4,14 @@
 #include "../game/wopg_spstoryfiles.h"
 #include "../game/wopg_sphandling.h"
 
-#define WSPM_START0		"menu/single/start0.tga"
-#define WSPM_START1		"menu/single/start1.tga"
+#define WSPM_START0		"menu/single/start0"
+#define WSPM_START1		"menu/single/start1"
 
-#define WSPM_CONTINUE0	"menu/single/continue0.tga"
-#define WSPM_CONTINUE1	"menu/single/continue1.tga"
+#define WSPM_CONTINUE0	"menu/single/continue0"
+#define WSPM_CONTINUE1	"menu/single/continue1"
 
-#define WSPM_EXIT0		"menu/single/exit0.tga"
-#define WSPM_EXIT1		"menu/single/exit1.tga"
+#define WSPM_EXIT0		"menu/single/exit0"
+#define WSPM_EXIT1		"menu/single/exit1"
 
 #define MAX_STORYELEMENTS	32
 #define MAX_CURRENTSTORYSTR	128
@@ -266,17 +266,17 @@ void WoPSPMenu_Init() {
 ####################### ####################### #######################
 */
 
-#define WSPC_FORWARD0	"menu/single/continue/forward0.tga"
-#define WSPC_FORWARD1	"menu/single/continue/forward1.tga"
+#define WSPC_FORWARD0	"menu/single/continue/forward0"
+#define WSPC_FORWARD1	"menu/single/continue/forward1"
 
-#define WSPC_BACKWARD0	"menu/single/continue/backward0.tga"
-#define WSPC_BACKWARD1	"menu/single/continue/backward1.tga"
+#define WSPC_BACKWARD0	"menu/single/continue/backward0"
+#define WSPC_BACKWARD1	"menu/single/continue/backward1"
 
-#define WSPC_START0		"menu/single/continue/start0.tga"
-#define WSPC_START1		"menu/single/continue/start1.tga"
+#define WSPC_START0		"menu/single/continue/start0"
+#define WSPC_START1		"menu/single/continue/start1"
 
-#define WSPC_EXIT0		"menu/single/continue/exit0.tga"
-#define WSPC_EXIT1		"menu/single/continue/exit1.tga"
+#define WSPC_EXIT0		"menu/single/continue/exit0"
+#define WSPC_EXIT1		"menu/single/continue/exit1"
 
 typedef struct {
 	menuframework_s	menu;
@@ -426,8 +426,8 @@ void WoPSPContinue_Init(void) {
 	wopSPcontinue.centerSE = wopSPmenu.lastAvailableSE;
 
 	wopSPcontinue.bg					= trap_R_RegisterShaderNoMip("menu/single/continue/background");
-	wopSPcontinue.gateLeft				= trap_R_RegisterShaderNoMip("menu/single/continue/gate_l.tga");
-	wopSPcontinue.gateRight				= trap_R_RegisterShaderNoMip("menu/single/continue/gate_r.tga");
+	wopSPcontinue.gateLeft				= trap_R_RegisterShaderNoMip("menu/single/continue/gate_l");
+	wopSPcontinue.gateRight				= trap_R_RegisterShaderNoMip("menu/single/continue/gate_r");
 	wopSPcontinue.menu.fullscreen		= qtrue;
 	wopSPcontinue.menu.draw				= WoPSPContinue_Draw;
 	wopSPcontinue.menu.noPushSelect		= qtrue;

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -2223,7 +2223,7 @@ Returns a uniqued list of files that match the given criteria
 from all search paths
 ===============
 */
-char **FS_ListFilteredFiles( const char *path, const char *extension, char *filter, int *numfiles, qboolean allowNonPureFilesOnDisk ) {
+static char **FS_ListFilteredFiles( const char *path, const char *extensions, char *filter, int *numfiles, qboolean allowNonPureFilesOnDisk ) {
 	int				nfiles;
 	char			**listCopy;
 	char			*list[MAX_FOUND_FILES];
@@ -2235,6 +2235,8 @@ char **FS_ListFilteredFiles( const char *path, const char *extension, char *filt
 	pack_t			*pak;
 	fileInPack_t	*buildBuffer;
 	char			zpath[MAX_ZPATH];
+	const char *extension;
+	char extensionBuf[128];
 
 	if ( !fs_searchpaths ) {
 		Com_Error( ERR_FATAL, "Filesystem call made without initialization" );
@@ -2244,93 +2246,112 @@ char **FS_ListFilteredFiles( const char *path, const char *extension, char *filt
 		*numfiles = 0;
 		return NULL;
 	}
-	if ( !extension ) {
-		extension = "";
+	if ( !extensions ) {
+		extensions = "";
 	}
 
 	pathLength = strlen( path );
 	if ( path[pathLength-1] == '\\' || path[pathLength-1] == '/' ) {
 		pathLength--;
 	}
-	extensionLength = strlen( extension );
+
+	Q_strncpyz(extensionBuf, extensions, sizeof(extensionBuf));
+	char *ext = extensionBuf;
 	nfiles = 0;
 	FS_ReturnPath(path, zpath, &pathDepth);
 
-	//
-	// search through the path, one element at a time, adding to list
-	//
-	for (search = fs_searchpaths ; search ; search = search->next) {
-		// is the element a pak file?
-		if (search->pack) {
-
-			//ZOID:  If we are pure, don't search for files on paks that
-			// aren't on the pure list
-			if ( !FS_PakIsPure(search->pack) ) {
-				continue;
-			}
-
-			// look through all the pak file elements
-			pak = search->pack;
-			buildBuffer = pak->buildBuffer;
-			for (i = 0; i < pak->numfiles; i++) {
-				char	*name;
-				int		zpathLen, depth;
-
-				// check for directory match
-				name = buildBuffer[i].name;
-				//
-				if (filter) {
-					// case insensitive
-					if (!Com_FilterPath( filter, name, qfalse ))
-						continue;
-					// unique the match
-					nfiles = FS_AddFileToList( name, list, nfiles );
-				}
-				else {
-
-					zpathLen = FS_ReturnPath(name, zpath, &depth);
-
-					if ( (depth-pathDepth)>2 || pathLength > zpathLen || Q_stricmpn( name, path, pathLength ) ) {
-						continue;
-					}
-
-					// check for extension match
-					length = strlen( name );
-					if ( length < extensionLength ) {
-						continue;
-					}
-
-					if ( Q_stricmp( name + length - extensionLength, extension ) ) {
-						continue;
-					}
-					// unique the match
-
-					temp = pathLength;
-					if (pathLength) {
-						temp++; // include the '/'
-					}
-					nfiles = FS_AddFileToList( name + temp, list, nfiles );
-				}
-			}
-		} else if (search->dir) { // scan for files in the filesystem
-			char	*netpath;
-			int		numSysFiles;
-			char	**sysFiles;
-			char	*name;
-
-			// don't scan directories for files if we are pure or restricted
-			if ( fs_numServerPaks && !allowNonPureFilesOnDisk ) {
-				continue;
+	for (;;) {
+		extension = ext;
+		if (*ext != '\0') {
+			char *next = strstr(ext, ";");
+			if (next != NULL) {
+				*next = '\0';
+				ext = next + 1;
 			} else {
-				netpath = FS_BuildOSPath( search->dir->path, search->dir->gamedir, path );
-				sysFiles = Sys_ListFiles( netpath, extension, filter, &numSysFiles, qfalse );
-				for ( i = 0 ; i < numSysFiles ; i++ ) {
-					// unique the match
-					name = sysFiles[i];
-					nfiles = FS_AddFileToList( name, list, nfiles );
-				}
-				Sys_FreeFileList( sysFiles );
+				ext = "";
 			}
+		}
+		extensionLength = strlen( extension );
+
+		//
+		// search through the path, one element at a time, adding to list
+		//
+		for (search = fs_searchpaths ; search ; search = search->next) {
+			// is the element a pak file?
+			if (search->pack) {
+
+				//ZOID:  If we are pure, don't search for files on paks that
+				// aren't on the pure list
+				if ( !FS_PakIsPure(search->pack) ) {
+					continue;
+				}
+
+				// look through all the pak file elements
+				pak = search->pack;
+				buildBuffer = pak->buildBuffer;
+				for (i = 0; i < pak->numfiles; i++) {
+					char	*name;
+					int		zpathLen, depth;
+
+					// check for directory match
+					name = buildBuffer[i].name;
+					//
+					if (filter) {
+						// case insensitive
+						if (!Com_FilterPath( filter, name, qfalse ))
+							continue;
+						// unique the match
+						nfiles = FS_AddFileToList( name, list, nfiles );
+					}
+					else {
+
+						zpathLen = FS_ReturnPath(name, zpath, &depth);
+
+						if ( (depth-pathDepth)>2 || pathLength > zpathLen || Q_stricmpn( name, path, pathLength ) ) {
+							continue;
+						}
+
+						// check for extension match
+						length = strlen( name );
+						if ( length < extensionLength ) {
+							continue;
+						}
+
+						if ( Q_stricmp( name + length - extensionLength, extension ) ) {
+							continue;
+						}
+						// unique the match
+
+						temp = pathLength;
+						if (pathLength) {
+							temp++; // include the '/'
+						}
+						nfiles = FS_AddFileToList( name + temp, list, nfiles );
+					}
+				}
+			} else if (search->dir) { // scan for files in the filesystem
+				char	*netpath;
+				int		numSysFiles;
+				char	**sysFiles;
+				char	*name;
+
+				// don't scan directories for files if we are pure or restricted
+				if ( fs_numServerPaks && !allowNonPureFilesOnDisk ) {
+					continue;
+				} else {
+					netpath = FS_BuildOSPath( search->dir->path, search->dir->gamedir, path );
+					sysFiles = Sys_ListFiles( netpath, extension, filter, &numSysFiles, qfalse );
+					for ( i = 0 ; i < numSysFiles ; i++ ) {
+						// unique the match
+						name = sysFiles[i];
+						nfiles = FS_AddFileToList( name, list, nfiles );
+					}
+					Sys_FreeFileList( sysFiles );
+				}
+			}
+		}
+		if (*ext == '\0') {
+			break;
 		}
 	}
 

--- a/code/renderercommon/tr_font.c
+++ b/code/renderercommon/tr_font.c
@@ -492,7 +492,7 @@ void RE_RegisterFont(const char *fontName, int pointSize, fontInfo_t *font) {
 				imageBuff[left++] = ((float)out[k] * max);
 			}
 
-			Com_sprintf (name, sizeof(name), "fonts/fontImage_%i_%i.tga", imageNumber++, pointSize);
+			Com_sprintf (name, sizeof(name), "fonts/fontImage_%i_%i", imageNumber++, pointSize);
 			if (r_saveFontData->integer) { 
 				WriteTGA(name, imageBuff, 256, 256);
 			}

--- a/code/renderergl1/tr_image.c
+++ b/code/renderergl1/tr_image.c
@@ -921,10 +921,10 @@ typedef struct
 // when there are multiple images of different formats available
 static imageExtToLoaderMap_t imageLoaders[ ] =
 {
+	{ "png",  R_LoadPNG },
 	{ "tga",  R_LoadTGA },
 	{ "jpg",  R_LoadJPG },
 	{ "jpeg", R_LoadJPG },
-	{ "png",  R_LoadPNG },
 	{ "pcx",  R_LoadPCX },
 	{ "bmp",  R_LoadBMP }
 };

--- a/code/renderergl1/tr_shader.c
+++ b/code/renderergl1/tr_shader.c
@@ -1267,7 +1267,7 @@ static void ParseSkyParms( char **text ) {
 	}
 	if ( strcmp( token, "-" ) ) {
 		for (i=0 ; i<6 ; i++) {
-			Com_sprintf( pathname, sizeof(pathname), "%s_%s.tga"
+			Com_sprintf( pathname, sizeof(pathname), "%s_%s"
 				, token, suf[i] );
 			shader.sky.outerbox[i] = R_FindImageFile( ( char * ) pathname, IMGTYPE_COLORALPHA, imgFlags | IMGFLAG_CLAMPTOEDGE );
 
@@ -1298,7 +1298,7 @@ static void ParseSkyParms( char **text ) {
 	}
 	if ( strcmp( token, "-" ) ) {
 		for (i=0 ; i<6 ; i++) {
-			Com_sprintf( pathname, sizeof(pathname), "%s_%s.tga"
+			Com_sprintf( pathname, sizeof(pathname), "%s_%s"
 				, token, suf[i] );
 			shader.sky.innerbox[i] = R_FindImageFile( ( char * ) pathname, IMGTYPE_COLORALPHA, imgFlags );
 			if ( !shader.sky.innerbox[i] ) {

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -1579,7 +1579,7 @@ static void ParseSkyParms( char **text ) {
 	}
 	if ( strcmp( token, "-" ) ) {
 		for (i=0 ; i<6 ; i++) {
-			Com_sprintf( pathname, sizeof(pathname), "%s_%s.tga"
+			Com_sprintf( pathname, sizeof(pathname), "%s_%s"
 				, token, suf[i] );
 			shader.sky.outerbox[i] = R_FindImageFile( ( char * ) pathname, IMGTYPE_COLORALPHA, imgFlags | IMGFLAG_CLAMPTOEDGE );
 
@@ -1610,7 +1610,7 @@ static void ParseSkyParms( char **text ) {
 	}
 	if ( strcmp( token, "-" ) ) {
 		for (i=0 ; i<6 ; i++) {
-			Com_sprintf( pathname, sizeof(pathname), "%s_%s.tga"
+			Com_sprintf( pathname, sizeof(pathname), "%s_%s"
 				, token, suf[i] );
 			shader.sky.innerbox[i] = R_FindImageFile( ( char * ) pathname, IMGTYPE_COLORALPHA, imgFlags );
 			if ( !shader.sky.innerbox[i] ) {

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -4638,7 +4638,7 @@ static qboolean Character_Parse(char **p) {
       }
     
       uiInfo.characterList[uiInfo.characterCount].headImage = -1;
-			uiInfo.characterList[uiInfo.characterCount].imageName = String_Alloc(va("models/players/heads/%s/icon_default.tga", uiInfo.characterList[uiInfo.characterCount].name));
+			uiInfo.characterList[uiInfo.characterCount].imageName = String_Alloc(va("models/players/heads/%s/icon_default", uiInfo.characterList[uiInfo.characterCount].name));
 
 	  if (tempStr && (!Q_stricmp(tempStr, "female"))) {
         uiInfo.characterList[uiInfo.characterCount].base = String_Alloc(va("Janet"));
@@ -5023,14 +5023,14 @@ static void UI_BuildQ3Model_List( void )
 	for (i=0; i<numdirs && uiInfo.q3HeadCount < MAX_PLAYERMODELS; i++,dirptr+=dirlen+1)
 	{
 		dirlen = strlen(dirptr);
-		
+
 		if (dirlen && dirptr[dirlen-1]=='/') dirptr[dirlen-1]='\0';
 
 		if (!strcmp(dirptr,".") || !strcmp(dirptr,".."))
 			continue;
-			
+
 		// iterate all skin files in directory
-		numfiles = trap_FS_GetFileList( va("models/players/%s",dirptr), "tga", filelist, 2048 );
+		numfiles = trap_FS_GetFileList( va("models/players/%s",dirptr), "tga;png", filelist, 2048 );
 		fileptr  = filelist;
 		for (j=0; j<numfiles && uiInfo.q3HeadCount < MAX_PLAYERMODELS;j++,fileptr+=filelen+1)
 		{

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -89,15 +89,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ART_FX_WHITE		"menu/art/fx_white"
 #define ART_FX_YELLOW		"menu/art/fx_yel"
 
-#define ASSET_GRADIENTBAR "ui/assets/gradientbar2.tga"
-#define ASSET_SCROLLBAR             "ui/assets/scrollbar.tga"
-#define ASSET_SCROLLBAR_ARROWDOWN   "ui/assets/scrollbar_arrow_dwn_a.tga"
-#define ASSET_SCROLLBAR_ARROWUP     "ui/assets/scrollbar_arrow_up_a.tga"
-#define ASSET_SCROLLBAR_ARROWLEFT   "ui/assets/scrollbar_arrow_left.tga"
-#define ASSET_SCROLLBAR_ARROWRIGHT  "ui/assets/scrollbar_arrow_right.tga"
-#define ASSET_SCROLL_THUMB          "ui/assets/scrollbar_thumb.tga"
-#define ASSET_SLIDER_BAR						"ui/assets/slider2.tga"
-#define ASSET_SLIDER_THUMB					"ui/assets/sliderbutt_1.tga"
+#define ASSET_GRADIENTBAR "ui/assets/gradientbar2"
+#define ASSET_SCROLLBAR             "ui/assets/scrollbar"
+#define ASSET_SCROLLBAR_ARROWDOWN   "ui/assets/scrollbar_arrow_dwn_a"
+#define ASSET_SCROLLBAR_ARROWUP     "ui/assets/scrollbar_arrow_up_a"
+#define ASSET_SCROLLBAR_ARROWLEFT   "ui/assets/scrollbar_arrow_left"
+#define ASSET_SCROLLBAR_ARROWRIGHT  "ui/assets/scrollbar_arrow_right"
+#define ASSET_SCROLL_THUMB          "ui/assets/scrollbar_thumb"
+#define ASSET_SLIDER_BAR						"ui/assets/slider2"
+#define ASSET_SLIDER_THUMB					"ui/assets/sliderbutt_1"
 #define SCROLLBAR_SIZE 16.0
 #define SLIDER_WIDTH 96.0
 #define SLIDER_HEIGHT 16.0


### PR DESCRIPTION
Added png support to spraylogos and skins.

most of the code parts are just removing the extension anyway. But this change allows us to replace an existing and referenced tga image with e.g. a png version
    
See issue #35 and #63
