### PR TITLE
MAKE: added target to format the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3114,6 +3114,12 @@ dist:
 %-debug: debug
 	cd $(BD) && gdb ./$(@:-debug=)$(FULLBINEXT) -ex run
 
+format-asm format-autoupdater format-botlib format-cgame format-client format-game format-null format-q3_ui format-qcommon format-renderercommon format-renderergl1 format-renderergl2 format-sdl format-server format-sys format-tools format-ui:
+	@find code/$(word 2,$(subst -, ,$@)) -name "*.[ch]" -exec clang-format -i {} \;
+
+format: format-asm format-autoupdater format-botlib format-cgame format-client format-game format-null format-q3_ui format-qcommon format-renderercommon format-renderergl1 format-renderergl2 format-sdl format-server format-sys format-tools format-ui
+
+
 #############################################################################
 # DEPENDENCIES
 #############################################################################

--- a/code/.clang-format
+++ b/code/.clang-format
@@ -94,7 +94,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true


### PR DESCRIPTION
updated clang-format config: disable header inclusion reordering

This is here to prepare the formatting of the code