### PR TITLE
CGAME: fixed item sounds - there is no wav extension anymore

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -660,9 +660,7 @@ static void CG_RegisterItemSounds( int itemNum ) {
 			s++;
 		}
 
-		if ( !strcmp(data+len-3, "wav" )) {
-			trap_S_RegisterSound( data, qfalse );
-		}
+		trap_S_RegisterSound( data, qfalse );
 	}
 }
 


### PR DESCRIPTION
see bg_itemlist array in bg_misc.c