### PR TITLE
CLIENT: Fixed issues with ogm cinematics in-game

### DIFF
--- a/code/client/cin_ogm.c
+++ b/code/client/cin_ogm.c
@@ -270,14 +270,14 @@ static qboolean loadAudio(cinematics_t* cin) {
 				ptr+=2;//numChans;
 			}
 
-			if(i>0) {
-				// tell libvorbis how many samples we actually consumed
-				vorbis_synthesis_read(&g_ogm.vd,i);
+			// tell libvorbis how many samples we actually consumed
+			vorbis_synthesis_read(&g_ogm.vd, i);
 
-				S_RawSamples( 0, i, g_ogm.vi.rate, 2, 2, rawBuffer, 1.0f, -1 );
-
-				anyDataTransferred = qtrue;
+			if (!(cin->flags & CIN_silent)) {
+				S_RawSamples(0, i, g_ogm.vi.rate, 2, g_ogm.vi.channels, rawBuffer, 1.0f, -1);
 			}
+
+			anyDataTransferred = qtrue;
 		}
 
 		if(!anyDataTransferred)	{

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -1530,6 +1530,8 @@ int CIN_PlayCinematic( const char *arg, int x, int y, int w, int h, int systemBi
 	Com_Memset(&cin, 0, sizeof(cinematics_t) );
 	currentHandle = CIN_HandleForVideo();
 
+	Com_Memset(&cinTable[currentHandle], 0, sizeof(cin_cache) );
+
 	cin.currentHandle = currentHandle;
 	cin.flags = systemBits;
 

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -586,6 +586,24 @@ void	SCR_DrawSmallChar( int x, int y, int ch );
 // cl_cin.c
 //
 
+#define DEFAULT_CIN_WIDTH	512
+#define DEFAULT_CIN_HEIGHT	512
+
+typedef struct {
+	byte linbuf[DEFAULT_CIN_WIDTH * DEFAULT_CIN_HEIGHT * 4 * 2];
+	byte file[65536];
+	short sqrTable[256];
+
+	int mcomp[256];
+	byte *qStatus[2][32768];
+
+	long oldXOff, oldYOff, oldysize, oldxsize;
+
+	int currentHandle;
+
+	int flags;
+} cinematics_t;
+
 void CL_CompleteCinematicName(char *args, int argNum);
 void CL_PlayCinematic_f( void );
 void SCR_DrawCinematic (void);
@@ -610,11 +628,10 @@ void Frame_yuv_to_rgb24( const unsigned char* y, const unsigned char* u, const u
 // cin_ogm.c
 //
 
-int Cin_OGM_Init(const char* filename);
-int Cin_OGM_Run(int time);
-unsigned char* Cin_OGM_GetOutput(int* outWidth, int* outHeight);
-void Cin_OGM_Shutdown(void);
-
+int Cin_OGM_Init(cinematics_t *cin, const char *filename);
+int Cin_OGM_Run(cinematics_t *cin, int time);
+unsigned char *Cin_OGM_GetOutput(cinematics_t *cin, int *outWidth, int *outHeight);
+void Cin_OGM_Shutdown(cinematics_t *cin);
 
 //
 // cl_cgame.c


### PR DESCRIPTION
If you start padcrash you will get an instant crash due to div0 in `loadAudio` (cin_ogm.c)