### PR TITLE
SERVER: hopefully fixed wrong human player count on servers

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -725,7 +725,7 @@ SortRanks
 
 =============
 */
-int QDECL SortRanks(const void *a, const void *b) {
+static int QDECL SortRanks(const void *a, const void *b) {
 	gclient_t *ca, *cb;
 
 	ca = &level.clients[*(int *)a];

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -620,12 +620,15 @@ void SVC_Info(netadr_t from) {
 
 	// don't count privateclients
 	count = humans = 0;
-	for (i = sv_privateClients->integer; i < sv_maxclients->integer; i++) {
-		if (svs.clients[i].state >= CS_CONNECTED) {
+	for (i = 0; i < sv_maxclients->integer; i++) {
+		if (svs.clients[i].state < CS_CONNECTED) {
+			continue;
+		}
+		if (i >= sv_privateClients->integer) {
 			count++;
-			if (svs.clients[i].netchan.remoteAddress.type != NA_BOT) {
-				humans++;
-			}
+		}
+		if (svs.clients[i].netchan.remoteAddress.type != NA_BOT) {
+			humans++;
 		}
 	}
 


### PR DESCRIPTION
there might have been an issue in the way the private client
slot were counted. If private clients were connected to a server,
they should not contribute to the max connected client count.
But they should get included in the human counter. This commit
should fix issue #31