### PR TITLE
GAME: hopefully fixed framerate dependent floater usage

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1377,6 +1377,7 @@ static void CG_DrawHoldableItem(float y) {
 
 	value = cg.snap->ps.stats[STAT_HOLDABLE_ITEM];
 	if (value) {
+		const int itemState = cg.snap->ps.stats[STAT_HOLDABLEVAR];
 		CG_RegisterItemVisuals(value);
 
 		y -= ICON_SIZE;
@@ -1386,19 +1387,17 @@ static void CG_DrawHoldableItem(float y) {
 		}
 
 		if (bg_itemlist[value].giTag == HI_FLOATER) {
-			vec4_t tmpcolor = {0.33f, 0.33f, 1.0f, 0.66f};
-
-			CG_FillRect(640 - ICON_SIZE - 10,
-						y + ICON_SIZE - (int)(ICON_SIZE * cg.snap->ps.stats[STAT_HOLDABLEVAR] * 0.0000333333f), 10,
-						(int)(ICON_SIZE * cg.snap->ps.stats[STAT_HOLDABLEVAR] * 0.0000333333f),
-						tmpcolor); //*0.0000333333f -> /30000
-			CG_DrawRect(640 - ICON_SIZE - 10, y, 10, ICON_SIZE, 1.0f, colorWhite);
-			//			CG_DrawStringExt(640-ICON_SIZE,(SCREEN_HEIGHT-ICON_SIZE)/2+16,va("%i",cg.snap->ps.stats[STAT_HOLDABLEVAR]),colorWhite,qtrue,qfalse,10,16,8);
+			const vec4_t barColor = {0.33f, 0.33f, 1.0f, 0.66f};
+			const float barFactor = 1.0f / (float)MAX_FLOATER;
+			const int barHeight = (int)(ICON_SIZE * itemState * barFactor);
+			const float barX = 640 - ICON_SIZE - 10;
+			CG_FillRect(barX, y + ICON_SIZE - barHeight, 10, barHeight, barColor);
+			CG_DrawRect(barX, y, 10, ICON_SIZE, 1.0f, colorWhite);
 		} else if (bg_itemlist[value].giTag == HI_KILLERDUCKS) {
-			CG_DrawStringExt(640 - 28, y + 8, va("%i", cg.snap->ps.stats[STAT_HOLDABLEVAR]), colorWhite, qtrue, qtrue,
+			CG_DrawStringExt(640 - 28, y + 8, va("%i", itemState), colorWhite, qtrue, qtrue,
 							 8, 16, 1);
 		} else if (bg_itemlist[value].giTag == HI_BOOMIES) {
-			CG_DrawStringExt(640 - 28, y + 8, va("%i", cg.snap->ps.stats[STAT_HOLDABLEVAR]), colorWhite, qtrue, qtrue,
+			CG_DrawStringExt(640 - 28, y + 8, va("%i", itemState), colorWhite, qtrue, qtrue,
 							 8, 16, 1);
 		}
 	}

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -1015,12 +1015,6 @@ static void CG_Station(centity_t *cent) {
 	if (cent->currentState.angles2[1] == 0.0f) {
 		vec3_t tmpangles;
 
-		/*
-				if(!(cg.frametime>200 || cg.frametime<1)) tmpi+=cg.frametime;
-		//		if(!(cg.clientFrame%2)) LaunchStationStar(ent.origin);
-				while(tmpi>40) { LaunchStationStar(ent.origin); tmpi-=40; }//20->40
-		*/
-
 		AnglesToAxis(cg.autoAngles, ent.axis);
 		ent.origin[2] += 48.0f + sin(cg.time * 0.005f) * 4.0f; // 24(oldmodel)->48(new)
 		ent.oldorigin[2] += 48.0f + sin(cg.time * 0.005f) * 4.0f;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1628,7 +1628,6 @@ void AddLFsToScreen(void);
 //
 void Init_SpriteParticles(void);
 void LaunchSpeedyPuffTrail(vec3_t origin);
-void LaunchFloaterPuff(vec3_t origin);
 void LaunchRevivalParticle(vec3_t origin, const int lifetime);
 void Main_SpriteParticles(void);
 

--- a/code/cgame/cg_spriteparticles.c
+++ b/code/cgame/cg_spriteparticles.c
@@ -428,47 +428,6 @@ void LaunchSpeedyPuffTrail(vec3_t origin) {
 		Com_Printf("changeerror=%i\n", tmpce);
 }
 
-// puff for floatering around °°
-// ... we won't use it ... we keep using the vq3-partikels, for this
-void LaunchFloaterPuff(vec3_t origin) {
-	sparticle_t *p;
-	changeerror_t tmpce;
-
-	p = Alloc_SpriteParticle();
-
-	p->starttime = cg.time;
-
-	p->currentshader = cgs.media.smokePuffShader;
-
-	p->endtime = cg.time + 4000;
-
-	p->origin[0] = origin[0];
-	p->origin[1] = origin[1];
-	p->origin[2] = origin[2];
-
-	p->radius = 10.0f;
-
-	p->velocity[0] = 0.0f;
-	p->velocity[1] = 0.0f;
-	p->velocity[2] = -2.0f;
-
-	p->vrandom[0] = 0.0f;
-	p->vrandom[1] = 0.2f;
-	p->vrandom[2] = 0.2f;
-
-	p->currentcolor[0] = 0.2f;
-	p->currentcolor[1] = 0.0f;
-	p->currentcolor[2] = 0.4f;
-	p->currentcolor[3] = 0.8f;
-
-	if ((tmpce = AddCCToParticle(p, 0, 1500, 0.6f, 0.4f, 1.0f, 0.80f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCCToParticle(p, 1500, 2000, 1.0f, 1.0f, 1.0f, 0.8f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCCToParticle(p, 2100, 2500, 1.0f, 1.0f, 1.0f, 0.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-}
-
 // not realy used ... because it looked realy ugly ^^
 void LaunchPunchyBerserker(vec3_t origin) {
 	sparticle_t *p;

--- a/code/cgame/cg_spriteparticles.c
+++ b/code/cgame/cg_spriteparticles.c
@@ -175,30 +175,7 @@ typedef enum {
 
 } changeerror_t;
 
-changeerror_t AddCSHToParticle(sparticle_t *p, int time, qhandle_t shader) {
-	changeshader_t *tmpcsh;
-
-	if (freecsh == NULL)
-		return CE_MEMFULL;
-
-	freecsh->time = time;
-	freecsh->shader = shader;
-
-	if (!p->csh) {
-		p->csh = freecsh;
-	} else {
-		for (tmpcsh = p->csh; tmpcsh->next != NULL; tmpcsh = tmpcsh->next)
-			;
-		tmpcsh->next = freecsh;
-	}
-	tmpcsh = freecsh->next;
-	freecsh->next = NULL;
-	freecsh = tmpcsh;
-
-	return CE_NOTHING;
-}
-
-changeerror_t AddCCToParticle(sparticle_t *p, int fadetime, int time, float r, float g, float b, float a) {
+static changeerror_t AddCCToParticle(sparticle_t *p, int fadetime, int time, float r, float g, float b, float a) {
 	changecolor_t *tmpcc;
 
 	if (freecc == NULL)
@@ -240,30 +217,7 @@ changeerror_t AddCCToParticle(sparticle_t *p, int fadetime, int time, float r, f
 	return CE_NOTHING;
 }
 
-changeerror_t AddCSIToParticle(sparticle_t *p, int time, float changepersecond) {
-	changesize_t *tmpcsi;
-
-	if (freecsi == NULL)
-		return CE_MEMFULL;
-
-	freecsi->time = time;
-	freecsi->changepersecond = changepersecond;
-
-	if (!p->csi) {
-		p->csi = freecsi;
-	} else {
-		for (tmpcsi = p->csi; tmpcsi->next != NULL; tmpcsi = tmpcsi->next)
-			;
-		tmpcsi->next = freecsi;
-	}
-	tmpcsi = freecsi->next;
-	freecsi->next = NULL;
-	freecsi = tmpcsi;
-
-	return CE_NOTHING;
-}
-
-sparticle_t *Alloc_SpriteParticle(void) {
+static sparticle_t *Alloc_SpriteParticle(void) {
 	sparticle_t *tmpp;
 
 	if (!freep) // we must free something
@@ -282,109 +236,6 @@ sparticle_t *Alloc_SpriteParticle(void) {
 		lastp = tmpp;
 
 	return tmpp;
-}
-
-// used long long long time ago *sight*
-void LaunchStationStar(vec3_t origin) {
-	sparticle_t *p;
-	changeerror_t tmpce;
-	float tmpcr;
-
-	p = Alloc_SpriteParticle();
-
-	p->starttime = cg.time;
-
-	p->currentshader = spritehandles.starts[(int)(random() * 2.99f)];
-
-	p->endtime = cg.time + 3000;
-
-	tmpcr = crandom();
-	p->origin[0] = origin[0] + tmpcr * 32.0f;
-	p->origin[1] = origin[1] + sin(acos(tmpcr)) * crandom() * 32.0f;
-	p->origin[2] = origin[2];
-
-	p->radius = 2.5f;
-
-	p->velocity[0] = 0.0f;
-	p->velocity[1] = 0.0f;
-	p->velocity[2] = 100.0f;
-
-	p->vrandom[0] = 1.0f;
-	p->vrandom[1] = 1.0f;
-	p->vrandom[2] = 1.0f;
-
-	p->acceleration[0] = 0.0f;
-	p->acceleration[1] = 0.0f;
-	p->acceleration[2] = -50.0f;
-
-	p->currentcolor[0] = p->currentcolor[1] = p->currentcolor[2] = p->currentcolor[3] = 1.0f;
-
-	if ((tmpce = AddCCToParticle(p, 2000, 3000, 1.0f, 1.0f, 1.0f, 0.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	/*
-		p->currentcolor[0] = 1.0f;
-		p->currentcolor[1] = 0.0f;
-		p->currentcolor[2] = 0.0f;
-		p->currentcolor[3] = 0.8f;
-
-		if(tmpce=AddCCToParticle(p,500,1500,1.0f,1.0f,0.0f,0.6f)) Com_Printf("changeerror=%i\n",tmpce);
-		if(tmpce=AddCCToParticle(p,2000,2000,0.0f,0.0f,0.0f,1.0f)) Com_Printf("changeerror=%i\n",tmpce);
-		if(tmpce=AddCCToParticle(p,3000,3500,0.0f,0.0f,0.0f,0.0f)) Com_Printf("changeerror=%i\n",tmpce);
-	*/
-}
-
-// playing around XD (you can see this in the credit menu ... if Ente hasn't removed it ;) )
-void LaunchSpiralParticle(vec3_t origin) {
-	sparticle_t *p;
-	changeerror_t tmpce;
-	//	float		tmpcr;
-
-	p = Alloc_SpriteParticle();
-
-	p->starttime = cg.time;
-
-	p->currentshader = cgs.media.whiteShader;
-
-	p->endtime = cg.time + 3000;
-
-	p->origin[0] = origin[0];
-	p->origin[1] = origin[1];
-	p->origin[2] = origin[2];
-
-	p->radius = 5.0f;
-
-	p->velocity[0] = 10.0f * sin((float)cg.time * 0.01f);
-	p->velocity[1] = 10.0f * cos((float)cg.time * 0.01f);
-	p->velocity[2] = -20.0f;
-
-	p->vrandom[0] = 0.0f;
-	p->vrandom[1] = 0.0f;
-	p->vrandom[2] = 0.0f;
-
-	p->acceleration[0] = 0.0f;
-	p->acceleration[1] = 0.0f;
-	p->acceleration[2] = 0.0f;
-
-	p->currentcolor[0] = 0.0f;
-	p->currentcolor[1] = 0.33f;
-	p->currentcolor[2] = 0.0f;
-	p->currentcolor[3] = 1.0f;
-
-	if ((tmpce = AddCCToParticle(p, 0, 2100, 0.0f, 1.0f, 0.0f, 1.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCCToParticle(p, 2100, 3000, 0.0f, 1.0f, 0.0f, 0.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-
-	/* rot->gelb->weiß->weg
-		p->currentcolor[0] = 1.0f;
-		p->currentcolor[1] = 0.0f;
-		p->currentcolor[2] = 0.0f;
-		p->currentcolor[3] = 1.0f;
-
-		if(tmpce=AddCCToParticle(p,1000,2000,1.0f,1.0f,0.0f,1.0f)) Com_Printf("changeerror=%i\n",tmpce);
-		if(tmpce=AddCCToParticle(p,2000,2100,1.0f,1.0f,1.0f,1.0f)) Com_Printf("changeerror=%i\n",tmpce);
-		if(tmpce=AddCCToParticle(p,2100,3000,1.0f,1.0f,1.0f,0.0f)) Com_Printf("changeerror=%i\n",tmpce);
-	*/
 }
 
 // puffs when running around with speedy
@@ -425,55 +276,6 @@ void LaunchSpeedyPuffTrail(vec3_t origin) {
 	if ((tmpce = AddCCToParticle(p, 2100, 3000, 1.0f, 1.0f, 1.0f, 0.8f)))
 		Com_Printf("changeerror=%i\n", tmpce);
 	if ((tmpce = AddCCToParticle(p, 3100, 4000, 1.0f, 1.0f, 1.0f, 0.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-}
-
-// not realy used ... because it looked realy ugly ^^
-void LaunchPunchyBerserker(vec3_t origin) {
-	sparticle_t *p;
-	changeerror_t tmpce;
-
-	p = Alloc_SpriteParticle();
-
-	p->starttime = cg.time;
-
-	p->currentshader = cgs.media.smokePuffShader;
-
-	p->endtime = cg.time + 4000;
-
-	p->origin[0] = origin[0];
-	p->origin[1] = origin[1];
-	p->origin[2] = origin[2];
-
-	p->radius = 8.0f;
-
-	p->velocity[0] = 0.0f;
-	p->velocity[1] = 0.0f;
-	p->velocity[2] = 20.0f;
-
-	p->vrandom[0] = 0.0f;
-	p->vrandom[1] = 5.0f;
-	p->vrandom[2] = 5.0f;
-
-	p->acceleration[0] = 0.0f;
-	p->acceleration[1] = 0.0f;
-	p->acceleration[2] = 0.0f;
-
-	p->currentcolor[0] = 1.0f;
-	p->currentcolor[1] = 0.0f;
-	p->currentcolor[2] = 0.0f;
-	p->currentcolor[3] = 0.7f;
-
-	if ((tmpce = AddCSIToParticle(p, 1000, -6.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCSIToParticle(p, 1100, 60.0f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-
-	if ((tmpce = AddCCToParticle(p, 0, 800, 1.0f, 0.66f, 0.0f, 0.20f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCCToParticle(p, 800, 1200, 0.0f, 0.0f, 0.0f, 0.33f)))
-		Com_Printf("changeerror=%i\n", tmpce);
-	if ((tmpce = AddCCToParticle(p, 1200, 1600, 0.0f, 0.0f, 0.0f, 0.0f)))
 		Com_Printf("changeerror=%i\n", tmpce);
 }
 
@@ -523,7 +325,7 @@ void LaunchRevivalParticle(vec3_t origin, const int lifetime) {
 		CHANGE_ERROR(tmpce);
 }
 
-void CheckCurrentStats(sparticle_t *p) {
+static void CheckCurrentStats(sparticle_t *p) {
 	float ftmp;
 	vec3_t oldOrigin;
 	trace_t tr;
@@ -602,7 +404,7 @@ void CheckCurrentStats(sparticle_t *p) {
 	p->velocity[2] += (p->acceleration[2] + p->vrandom[2] * ftmp) * (float)cg.frametime * 0.001f;
 }
 
-void AddSpriteParticleToScene(sparticle_t *p) {
+static void AddSpriteParticleToScene(sparticle_t *p) {
 	polyVert_t verts[4];
 
 	if (p->radius == 0)

--- a/code/game/bg_game.h
+++ b/code/game/bg_game.h
@@ -112,8 +112,8 @@
 
 // Holdables
 // TODO: Merge into existing vars above?
-#define MAX_FLOATER 30000
-#define FLOATER_USAGE_PER_MS 5
+#define MAX_FLOATER 8000
+#define FLOATER_USAGE_PER_MS 1
 #define MAX_KILLERDUCKS 5
 #define MAX_BOOMIES 3
 #define MAX_BAMBAMS 1

--- a/code/game/bg_game.h
+++ b/code/game/bg_game.h
@@ -113,6 +113,7 @@
 // Holdables
 // TODO: Merge into existing vars above?
 #define MAX_FLOATER 30000
+#define FLOATER_USAGE_PER_MS 5
 #define MAX_KILLERDUCKS 5
 #define MAX_BOOMIES 3
 #define MAX_BAMBAMS 1

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1528,8 +1528,7 @@ static void PM_Weapon(void) {
 
 				pm->ps->eFlags |= EF_FLOATER;
 
-				pm->ps->stats[STAT_HOLDABLEVAR] -=
-					50; // FIXME: it would be better if the value gets calculated from framerate ...
+				pm->ps->stats[STAT_HOLDABLEVAR] -= FLOATER_USAGE_PER_MS * pml.msec;
 				if (pm->ps->stats[STAT_HOLDABLEVAR] <= 0) {
 					pm->ps->pm_flags |= PMF_USE_ITEM_HELD;
 					pm->ps->stats[STAT_HOLDABLEVAR] = 0;

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1194,6 +1194,7 @@ typedef struct playerState_s {
 	int damagePitch;
 	int damageCount;
 
+	// these values are transmitted as short values in the snapshot
 	int stats[MAX_STATS];
 	int persistant[MAX_PERSISTANT]; // stats that aren't cleared on death
 	int powerups[MAX_POWERUPS];		// level.time that the powerup runs out


### PR DESCRIPTION
Also removed unused code that I came by while looking for the floater code.

The time for the floater is now 8 seconds. The runtime can be configured by the define `MAX_FLOATER`. As long as `FLOATER_USAGE_PER_MS` is `1` this value is the exact milliseconds of the floater runtime.

Also cleaned up the code to reduce code duplication and hard to find magic number usage.