### PR TITLE
UI: added basic cl_voipSendTarget support to the ui

### DIFF
--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -308,6 +308,7 @@ extern void Menu_SetCursor(menuframework_s *s, int cursor);
 extern void Menu_SetCursorToItem(menuframework_s *m, void *ptr);
 extern sfxHandle_t Menu_DefaultKey(menuframework_s *s, int key);
 extern sfxHandle_t ScrollList_Key(menulist_s *l, int key);
+extern void SpinControl_Init(menulist_s *s);
 
 extern sfxHandle_t menu_move_sound;
 extern sfxHandle_t menu_switch_sound;

--- a/code/ui/ui_qmenu.c
+++ b/code/ui/ui_qmenu.c
@@ -729,7 +729,7 @@ static void Slider_Draw(menuslider_s *s) {
 SpinControl_Init
 =================
 */
-static void SpinControl_Init(menulist_s *s) {
+void SpinControl_Init(menulist_s *s) {
 	int len;
 	int l;
 	const char *str;

--- a/code/ui/ui_serverinfo.c
+++ b/code/ui/ui_serverinfo.c
@@ -8,7 +8,6 @@
 #define ARROWDOWN1 "menu/server/arrowdown1"
 
 static char *serverinfo_artlist[] = {ARROWUP0, ARROWUP1, ARROWDOWN0, ARROWDOWN1,
-
 									 NULL};
 
 #define ID_ADD 100


### PR DESCRIPTION
![Bildschirmfoto von 2021-09-14 22-11-45](https://user-images.githubusercontent.com/577713/133327182-c4be0cbc-a6bd-40aa-9b41-3aa0d31b4681.png) (don't mind the dark look - there was an overlay of my windowmanager active at that time)

![Bildschirmfoto von 2021-09-14 22-14-05](https://user-images.githubusercontent.com/577713/133327409-c96dff2d-2352-4239-945b-c50d9a8e8e45.png)


See https://github.com/PadWorld-Entertainment/worldofpadman/discussions/138